### PR TITLE
SetUp basic user roles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ django-zDesk is a Django simple ticketing system
 [![GitHub](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/tiagocordeiro/django-zdesk/blob/master/LICENSE)
 [![codecov](https://codecov.io/gh/tiagocordeiro/django-zdesk/branch/master/graph/badge.svg)](https://codecov.io/gh/tiagocordeiro/django-zdesk)
 [![Build Status](https://travis-ci.org/tiagocordeiro/django-zdesk.svg?branch=master)](https://travis-ci.org/tiagocordeiro/django-zdesk)
+![Python application](https://github.com/tiagocordeiro/django-zdesk/workflows/Python%20application/badge.svg)
 
 ### Como rodar o projeto
 * Clone esse repositório.
@@ -31,6 +32,12 @@ python manage.py migrate
 Para cria um usuário administrador
 ```
 python manage.py createsuperuser --username dev --email dev@foo.bar
+```
+
+### Configurar grupos de usuários
+Cria grupos de usuários: [ `gerente` , `operador` ]
+```
+python manage.py loaddata core/fixtures/groups.json
 ```
 
 ### Rodar em ambiente de desenvolvimento

--- a/core/fixtures/groups.json
+++ b/core/fixtures/groups.json
@@ -1,0 +1,20 @@
+[
+{
+  "model": "auth.group",
+  "pk": 1,
+  "fields": {
+    "name": "gerente",
+    "permissions": [
+      37
+    ]
+  }
+},
+{
+  "model": "auth.group",
+  "pk": 2,
+  "fields": {
+    "name": "operador",
+    "permissions": []
+  }
+}
+]

--- a/core/templatetags/core_extras.py
+++ b/core/templatetags/core_extras.py
@@ -18,3 +18,8 @@ def currency_display(valor):
     locale.setlocale(locale.LC_ALL, 'pt_BR.UTF-8')
     valor = locale.currency(valor, grouping=True, symbol=None)
     return valor
+
+
+@register.filter(name='has_group')
+def has_group(user, group_name):
+    return user.groups.filter(name=group_name).exists()

--- a/helpdesk/views.py
+++ b/helpdesk/views.py
@@ -1,5 +1,5 @@
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import login_required, permission_required
 from django.http import JsonResponse
 from django.shortcuts import render, redirect, get_object_or_404
 from django.urls import reverse
@@ -77,6 +77,7 @@ def load_questions(request):
 
 
 @login_required
+@permission_required('helpdesk.add_ticket', raise_exception=True)
 def ticket_add(request):
     if request.method == 'POST':
         form = TicketForm(request.POST)

--- a/templates/403.html
+++ b/templates/403.html
@@ -1,0 +1,56 @@
+<!doctype html>
+{% load static %}
+<html class="no-js " lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+    <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
+    <meta name="description" content="Django simple ticketing system">
+
+    <title>403 :: zDesk ::</title>
+    <!-- Favicon-->
+    <link rel="icon" href="{% static 'favicon.png' %}" type="image/png"> <!-- Favicon-->
+    <!-- Custom Css -->
+    <link rel="stylesheet" href="{% static 'assets/plugins/bootstrap/css/bootstrap.min.css' %}">
+    <link rel="stylesheet" href="{% static 'assets/css/style.min.css' %}">
+</head>
+
+<body class="theme-blush">
+
+<div class="authentication">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-4 col-sm-12">
+                <form class="card auth_form">
+                    <div class="header">
+                        <img class="logo" src="{% static 'assets/images/logo.svg' %}" alt="">
+                        <h5>Error 403</h5>
+                        <span>Acesso negado!</span>
+                    </div>
+                    <div class="body">
+                        <a href="{% url 'dashboard' %}" class="btn btn-primary btn-block waves-effect waves-light">DASHBOARD</a>
+                        <div class="signin_with mt-3">
+                            <a href="javascript:void(0);" class="link">Precisa de ajuda?</a>
+                        </div>
+                    </div>
+                </form>
+                <div class="copyright text-center">
+                    &copy;
+                    <script>document.write(new Date().getFullYear())</script>
+                    <span><a href="{% url 'dashboard' %}">zDesk</a></span>
+                </div>
+            </div>
+            <div class="col-lg-8 col-sm-12">
+                <div class="card">
+                    <img src="{% static 'assets/images/maintanance.svg' %}"/>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Jquery Core Js -->
+<script src="{% static 'assets/bundles/libscripts.bundle.js' %}"></script>
+<script src="{% static 'assets/bundles/vendorscripts.bundle.js' %}"></script> <!-- Lib Scripts Plugin Js -->
+</body>
+</html>

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,56 @@
+<!doctype html>
+{% load static %}
+<html class="no-js " lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+    <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
+    <meta name="description" content="Django simple ticketing system">
+
+    <title>404 :: zDesk ::</title>
+    <!-- Favicon-->
+    <link rel="icon" href="{% static 'favicon.png' %}" type="image/png"> <!-- Favicon-->
+    <!-- Custom Css -->
+    <link rel="stylesheet" href="{% static 'assets/plugins/bootstrap/css/bootstrap.min.css' %}">
+    <link rel="stylesheet" href="{% static 'assets/css/style.min.css' %}">
+</head>
+
+<body class="theme-blush">
+
+<div class="authentication">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-4 col-sm-12">
+                <form class="card auth_form">
+                    <div class="header">
+                        <img class="logo" src="{% static 'assets/images/logo.svg' %}" alt="">
+                        <h5>Error 404</h5>
+                        <span>Não encontrado!</span>
+                    </div>
+                    <div class="body">
+                        <a href="{% url 'dashboard' %}" class="btn btn-primary btn-block waves-effect waves-light">DASHBOARD</a>
+                        <div class="signin_with mt-3">
+                            <a href="javascript:void(0);" class="link">Precisa de ajuda?</a>
+                        </div>
+                    </div>
+                </form>
+                <div class="copyright text-center">
+                    &copy;
+                    <script>document.write(new Date().getFullYear())</script>
+                    <span><a href="{% url 'dashboard' %}">zDesk</a></span>
+                </div>
+            </div>
+            <div class="col-lg-8 col-sm-12">
+                <div class="card">
+                    <img src="{% static 'assets/images/404.svg' %}"/>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Jquery Core Js -->
+<script src="{% static 'assets/bundles/libscripts.bundle.js' %}"></script>
+<script src="{% static 'assets/bundles/vendorscripts.bundle.js' %}"></script> <!-- Lib Scripts Plugin Js -->
+</body>
+</html>

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,0 +1,56 @@
+<!doctype html>
+{% load static %}
+<html class="no-js " lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+    <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
+    <meta name="description" content="Django simple ticketing system">
+
+    <title>500 :: zDesk ::</title>
+    <!-- Favicon-->
+    <link rel="icon" href="{% static 'favicon.png' %}" type="image/png"> <!-- Favicon-->
+    <!-- Custom Css -->
+    <link rel="stylesheet" href="{% static 'assets/plugins/bootstrap/css/bootstrap.min.css' %}">
+    <link rel="stylesheet" href="{% static 'assets/css/style.min.css' %}">
+</head>
+
+<body class="theme-blush">
+
+<div class="authentication">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-4 col-sm-12">
+                <form class="card auth_form">
+                    <div class="header">
+                        <img class="logo" src="{% static 'assets/images/logo.svg' %}" alt="">
+                        <h5>Error 500</h5>
+                        <span>Algo está quebrado :-(</span>
+                    </div>
+                    <div class="body">
+                        <a href="{% url 'dashboard' %}" class="btn btn-primary btn-block waves-effect waves-light">DASHBOARD</a>
+                        <div class="signin_with mt-3">
+                            <a href="javascript:void(0);" class="link">Precisa de ajuda?</a>
+                        </div>
+                    </div>
+                </form>
+                <div class="copyright text-center">
+                    &copy;
+                    <script>document.write(new Date().getFullYear())</script>
+                    <span><a href="{% url 'dashboard' %}">zDesk</a></span>
+                </div>
+            </div>
+            <div class="col-lg-8 col-sm-12">
+                <div class="card">
+                    <img src="{% static 'assets/images/404.svg' %}"/>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Jquery Core Js -->
+<script src="{% static 'assets/bundles/libscripts.bundle.js' %}"></script>
+<script src="{% static 'assets/bundles/vendorscripts.bundle.js' %}"></script> <!-- Lib Scripts Plugin Js -->
+</body>
+</html>

--- a/templates/core/main-nav.html
+++ b/templates/core/main-nav.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load core_extras %}
 <!-- Left Sidebar -->
 <aside id="leftsidebar" class="sidebar">
     <div class="navbar-brand">
@@ -25,7 +26,9 @@
             <li><a href="{% url 'dashboard' %}"><i class="zmdi zmdi-home"></i><span>Dashboard</span></a></li>
             <li><a href="javascript:void(0);" class="menu-toggle"><i class="zmdi zmdi-ticket-star"></i><span>Tickets</span></a>
                 <ul class="ml-menu">
-                    <li><a href="{% url 'ticket_add' %}">Adicionar</a></li>
+                    {% if request.user|has_group:"gerente" or request.user.is_superuser %}
+                        <li><a href="{% url 'ticket_add' %}">Adicionar</a></li>
+                    {% endif %}
                     <li><a href="{% url 'ticket_list_all' %}">Todos</a></li>
                     <li><a href="{% url 'ticket_list_todo' %}">Para fazer</a></li>
                     <li><a href="{% url 'ticket_list_processing' %}">Fazendo</a></li>


### PR DESCRIPTION
- Configura regras simples para grupos de usuários (em testes)
- Adiciona fixture para auth.group [`gerente`,`operador`]
- New templates for 403, 404 e 500 pages
- Adiciona GHActions badge ao README.md
- Adiciona `template tag` para checar se o usuário é de um grupo
  `{% if request.user|has_group:"gerente"}` :: retorna `True` ou `False`

This close #34